### PR TITLE
Improve frontend error handling

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,16 +1,19 @@
-async function fetchList(path) {
-  const res = await fetch(`http://localhost:3000/api/${path}`);
-  return res.json();
+async function fetchList(path, retries = 1) {
+  try {
+    const res = await fetch(`http://localhost:3000/api/${path}`);
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    return await res.json();
+  } catch (err) {
+    if (retries > 0) {
+      return fetchList(path, retries - 1);
+    }
+    throw err;
+  }
 }
 
 async function render() {
-  const [games, predictions, challenges, leaderboard] = await Promise.all([
-    fetchList('games'),
-    fetchList('predictions'),
-    fetchList('challenges'),
-    fetchList('leaderboard')
-  ]);
-
   const appendList = (id, items, formatter) => {
     const ul = document.getElementById(id);
     items.forEach(item => {
@@ -20,10 +23,31 @@ async function render() {
     });
   };
 
-  appendList('games', games, g => g.name);
-  appendList('predictions', predictions, p => p.question);
-  appendList('challenges', challenges, c => `${c.name} – ${c.reward}`);
-  appendList('leaderboard', leaderboard, u => `${u.user}: ${u.points}`);
+  const displayError = (id, message) => {
+    const ul = document.getElementById(id);
+    const li = document.createElement('li');
+    li.textContent = message;
+    ul.appendChild(li);
+  };
+
+  const sections = [
+    { id: 'games', path: 'games', formatter: g => g.name, error: 'Failed to load games.' },
+    { id: 'predictions', path: 'predictions', formatter: p => p.question, error: 'Failed to load predictions.' },
+    { id: 'challenges', path: 'challenges', formatter: c => `${c.name} – ${c.reward}`, error: 'Failed to load challenges.' },
+    { id: 'leaderboard', path: 'leaderboard', formatter: u => `${u.user}: ${u.points}`, error: 'Failed to load leaderboard.' }
+  ];
+
+  await Promise.all(
+    sections.map(async ({ id, path, formatter, error }) => {
+      try {
+        const items = await fetchList(path, 1);
+        appendList(id, items, formatter);
+      } catch (err) {
+        console.error(error, err);
+        displayError(id, error);
+      }
+    })
+  );
 }
 
 render();


### PR DESCRIPTION
## Summary
- add retry logic and error handling for API fetches in the frontend
- log and display friendly messages when lists fail to load

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdc3a23588329b2e8344ada92a1ac