### PR TITLE
Add CORS whitelist and route input validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/routes/challenges.js
+++ b/backend/routes/challenges.js
@@ -2,7 +2,15 @@ const express = require('express');
 const router = express.Router();
 
 // Active challenges
-router.get('/', (req, res) => {
+router.get('/', (req, res, next) => {
+  const { active } = req.query;
+  if (active !== undefined && !['true', 'false'].includes(active)) {
+    return next({
+      status: 400,
+      errors: [{ msg: 'active must be boolean', param: 'active' }]
+    });
+  }
+
   res.json([
     { id: 1, name: '10k Steps Challenge', reward: '₦100 airtime' }
   ]);

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -2,11 +2,25 @@ const express = require('express');
 const router = express.Router();
 
 // List available games
-router.get('/', (req, res) => {
-  res.json([
+router.get('/', (req, res, next) => {
+  const { id } = req.query;
+  if (id !== undefined && !/^\d+$/.test(id)) {
+    return next({
+      status: 400,
+      errors: [{ msg: 'id must be an integer', param: 'id' }]
+    });
+  }
+
+  const games = [
     { id: 1, name: 'Trivia' },
     { id: 2, name: 'Spin & Win' }
-  ]);
+  ];
+
+  if (id) {
+    return res.json(games.filter(g => g.id === Number(id)));
+  }
+
+  res.json(games);
 });
 
 module.exports = router;

--- a/backend/routes/leaderboard.js
+++ b/backend/routes/leaderboard.js
@@ -2,11 +2,25 @@ const express = require('express');
 const router = express.Router();
 
 // Hustle leaderboard placeholder
-router.get('/', (req, res) => {
-  res.json([
+router.get('/', (req, res, next) => {
+  const { limit } = req.query;
+  if (limit !== undefined && (!/^\d+$/.test(limit) || Number(limit) < 1)) {
+    return next({
+      status: 400,
+      errors: [{ msg: 'limit must be a positive integer', param: 'limit' }]
+    });
+  }
+
+  let leaders = [
     { user: 'Ada', points: 1200 },
     { user: 'Tunde', points: 950 }
-  ]);
+  ];
+
+  if (limit) {
+    leaders = leaders.slice(0, Number(limit));
+  }
+
+  res.json(leaders);
 });
 
 module.exports = router;

--- a/backend/routes/predictions.js
+++ b/backend/routes/predictions.js
@@ -2,7 +2,15 @@ const express = require('express');
 const router = express.Router();
 
 // Daily prediction stub
-router.get('/', (req, res) => {
+router.get('/', (req, res, next) => {
+  const { date } = req.query;
+  if (date !== undefined && isNaN(Date.parse(date))) {
+    return next({
+      status: 400,
+      errors: [{ msg: 'date must be ISO8601', param: 'date' }]
+    });
+  }
+
   res.json([
     { id: 1, question: 'Will it rain in Lagos today?' }
   ]);

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,13 +8,38 @@ const challengesRouter = require('./routes/challenges');
 const leaderboardRouter = require('./routes/leaderboard');
 
 const app = express();
-app.use(cors());
+
+// Allow only specific origins via CORS
+const allowedOrigins = [
+  'http://localhost:3000'
+];
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Not allowed by CORS'));
+    }
+  })
+);
+
 app.use(bodyParser.json());
 
 app.use('/api/games', gamesRouter);
 app.use('/api/predictions', predictionsRouter);
 app.use('/api/challenges', challengesRouter);
 app.use('/api/leaderboard', leaderboardRouter);
+
+// Centralized error handler
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  if (err.errors) {
+    return res.status(status).json({ errors: err.errors });
+  }
+  res.status(status).json({ error: err.message || 'Internal Server Error' });
+});
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- restrict CORS to a whitelist of allowed origins
- validate query parameters on all API routes
- centralize error handling for consistent validation responses

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdec075cc8329a14aeafa222a3d25